### PR TITLE
Separate connect & enable crypto

### DIFF
--- a/src/main/php/peer/CryptoSocket.class.php
+++ b/src/main/php/peer/CryptoSocket.class.php
@@ -8,6 +8,40 @@ use security\cert\X509Certificate;
  */
 class CryptoSocket extends Socket {
   const CTX_WRP = 'ssl';      // stream context option key
+  protected $crpytoImpl= null;
+
+  /**
+   * Connect, then enable crypto
+   * 
+   * @param   float  $timeout
+   * @return  bool
+   * @throws  peer.SocketException
+   */
+  public function connect($timeout= 2.0) {
+    if ($this->isConnected()) return true;
+
+    parent::connect($timeout);
+
+    if (stream_socket_enable_crypto($this->_sock, true, $this->cryptoImpl)) {
+      return true;
+    }
+
+    // Parse OpenSSL errors:
+    if (preg_match('/error:(\d+):(.+)/', key(end(\xp::$errors[__FILE__])), $matches)) {
+      switch ($matches[1]) {
+        case '14090086':
+          $e= new SSLUnverifiedPeerException($matches[2]); break;
+
+        default:
+          $e= new SSLHandshakeException($matches[2]); break;
+      }
+    } else {
+      $e= new SSLHandshakeException('Unable to enable crypto.');
+    }
+
+    $this->close();
+    throw $e;
+  }
 
   /**
    * Set verify peer

--- a/src/main/php/peer/CryptoSocket.class.php
+++ b/src/main/php/peer/CryptoSocket.class.php
@@ -13,9 +13,11 @@ class CryptoSocket extends Socket {
   /**
    * Connect, then enable crypto
    * 
-   * @param   float  $timeout
+   * @param   float $timeout
    * @return  bool
-   * @throws  peer.SocketException
+   * @throws  peer.SSLUnverifiedPeerException if peer verification fails
+   * @throws  peer.SSLHandshakeException if handshake fails for any other reasons
+   * @throws  peer.ConnectException for all other reasons
    */
   public function connect($timeout= 2.0) {
     if ($this->isConnected()) return true;

--- a/src/main/php/peer/SSLHandshakeException.class.php
+++ b/src/main/php/peer/SSLHandshakeException.class.php
@@ -1,0 +1,4 @@
+<?php namespace peer;
+
+class SSLHandshakeException extends ConnectException {
+}

--- a/src/main/php/peer/SSLSocket.class.php
+++ b/src/main/php/peer/SSLSocket.class.php
@@ -23,6 +23,12 @@ class SSLSocket extends CryptoSocket {
    */
   public function __construct($host, $port, $socket= null, $version= null) {
     parent::__construct($host, $port, $socket);
-    $this->_prefix= 'ssl'.($version ? 'v'.$version : '').'://';
+    switch ($version) {
+      case 2: $this->cryptoImpl= STREAM_CRYPTO_METHOD_SSLv2_CLIENT; break;
+      case 3: $this->cryptoImpl= STREAM_CRYPTO_METHOD_SSLv3_CLIENT; break;
+
+      default:
+        $this->cryptoImpl= STREAM_CRYPTO_METHOD_SSLv23_CLIENT; break;
+    }
   }
 }

--- a/src/main/php/peer/SSLUnverifiedPeerException.class.php
+++ b/src/main/php/peer/SSLUnverifiedPeerException.class.php
@@ -1,0 +1,4 @@
+<?php namespace peer;
+
+class SSLUnverifiedPeerException extends SSLHandshakeException {
+}

--- a/src/main/php/peer/TLSSocket.class.php
+++ b/src/main/php/peer/TLSSocket.class.php
@@ -16,6 +16,6 @@ class TLSSocket extends CryptoSocket {
    */
   public function __construct($host, $port, $socket= null) {
     parent::__construct($host, $port, $socket);
-    $this->_prefix= 'tls://';
+    $this->cryptoImpl= STREAM_CRYPTO_METHOD_TLS_CLIENT;
   }
 }


### PR DESCRIPTION
This way, SSL / TLS errors can be distinguished from connection failures
on the network layer.

Introduce SSLHandshakeException, SSLUnverifiedPeerException at this
point, so it becomes possible to specifically catch those later.
