### PR TITLE
Add option to control server via socket

### DIFF
--- a/src/main/php/peer/server/Controllable.class.php
+++ b/src/main/php/peer/server/Controllable.class.php
@@ -1,0 +1,15 @@
+<?php namespace peer\server;
+
+interface Controllable {
+
+  /**
+   * Use the given address as control socket, e.g. for shutting down!
+   *
+   * @param  string $addr
+   * @param  int $port
+   * @param  [:function(string, peer.Socket, peer.server.Server)] $handlers
+   * @return self
+   */
+  public function attach($addr, $port, $handlers= []);
+
+}


### PR DESCRIPTION
Would be necessary to gracefully shut down the standalone server in https://github.com/xp-runners/reference/pull/70 and the following additional patch:

```diff
diff --git a/src/main/php/xp/web/Standalone.class.php b/src/main/php/xp/web/Standalone.class.php
index 5b7c761..57a4f13 100755
--- a/src/main/php/xp/web/Standalone.class.php
+++ b/src/main/php/xp/web/Standalone.class.php
@@ -2,6 +2,7 @@

 use util\cmd\Console;
 use web\Environment;
+use peer\server\Controllable;

 abstract class Standalone {
   private $server, $url;
@@ -47,7 +48,17 @@ abstract class Standalone {
     Console::writeLine('  PID ', getmypid(), '; press Ctrl+C to exit');
     Console::writeLine();

+    // Inside `xp -supervise`, connect to signalling socket
+    if ($port= getenv('XP_SIGNAL') && $this->server instanceof Controllable) {
+      $this->server->attach('127.0.0.1', $port, [
+        'QUIT' => function($command, $socket, $server) { $server->terminate= true; }
+      ]);
+    }
+
     $this->server->service();
     $this->server->shutdown();
+
+    Console::writeLine();
+    Console::writeLine("\e[33;1m>\e[0m Server stopped. (", date('r'), ')');
   }
 }
```