### PR TITLE
Pass SOMAXCONN to listen() call

### DIFF
--- a/src/main/php/peer/server/Server.class.php
+++ b/src/main/php/peer/server/Server.class.php
@@ -44,7 +44,7 @@ class Server {
   public function init() {
     $this->socket->create();
     $this->socket->bind(true);
-    $this->socket->listen();
+    $this->socket->listen(SOMAXCONN);
   }
   
   /**


### PR DESCRIPTION
This increases server performance threefold and drops the socket errors

## Fixture
```php
<?php

class Hello extends \web\Application {

  public function routes() {
    return [
      '/' => function($req, $res) {
        $res->answer(200, 'OK');
        $res->header('Connection', 'close');
        $res->send('Hello World', 'text/plain');
      }
    ];
  }
}
```

## Before
```bash
$ wrk -t 2 -c 20 http://127.0.0.1:8080/
Running 10s test @ http://127.0.0.1:8080/
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     5.95ms    9.31ms  79.24ms   90.72%
    Req/Sec   656.79    501.01     1.39k    58.12%
  7859 requests in 10.07s, 1.15MB read
  Socket errors: connect 20, read 0, write 1, timeout 0
Requests/sec:    780.72
Transfer/sec:    117.41KB
```

## After
```bash
$ wrk -t 2 -c 20 http://127.0.0.1:8080/
Running 10s test @ http://127.0.0.1:8080/
  2 threads and 20 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     3.99ms    2.90ms  57.64ms   84.68%
    Req/Sec     1.08k   200.79     1.46k    80.81%
  21530 requests in 10.09s, 3.16MB read
Requests/sec:   2133.38
Transfer/sec:    320.84KB
```

See https://msdn.microsoft.com/en-us/library/windows/desktop/ms739168(v=vs.85).aspx
See https://stackoverflow.com/questions/18073483/what-do-somaxconn-mean-in-c-socket-programming