### PR TITLE
Raise exceptions when pcntl extension is not loaded or disabled

### DIFF
--- a/src/main/php/peer/server/ForkingServer.class.php
+++ b/src/main/php/peer/server/ForkingServer.class.php
@@ -9,6 +9,7 @@ use lang\SystemException;
  * @see   xp://peer.server.Server
  */
 class ForkingServer extends Server {
+  use Pcntl;
   
   /**
    * Service

--- a/src/main/php/peer/server/Pcntl.class.php
+++ b/src/main/php/peer/server/Pcntl.class.php
@@ -1,0 +1,18 @@
+<?php namespace peer\server;
+
+use lang\IllegalAccessException;
+
+trait Pcntl {
+
+  static function __static() {
+    if (!extension_loaded('pcntl')) {
+      throw new IllegalAccessException('PCNTL extension not available');
+    }
+
+    // https://stackoverflow.com/questions/16262854/pcntl-not-working-on-ubuntu-for-security-reasons
+    $disabled= ini_get('disable_functions');
+    if (strstr($disabled, 'pcntl_fork')) {
+      throw new IllegalAccessException('PCNTL functions disabled via PHP configuration (disable_functions='.$disabled.')');
+    }
+  }
+}

--- a/src/main/php/peer/server/PreforkingServer.class.php
+++ b/src/main/php/peer/server/PreforkingServer.class.php
@@ -10,6 +10,8 @@ use util\log\Traceable;
  * @see   xp://peer.server.Server
  */
 class PreforkingServer extends Server implements Traceable {
+  use Pcntl;
+
   public
     $cat          = null,
     $count        = 0,


### PR DESCRIPTION
Previously, this would fail more or less silently later on (`pnctl_fork()` returns NULL when it has been disabled). Now, an exception is raised during class loading:

![image](https://user-images.githubusercontent.com/696742/46572027-9d300680-c97f-11e8-94a9-debb79c188e9.png)

![image](https://user-images.githubusercontent.com/696742/46572039-cbade180-c97f-11e8-9e9b-e5f6aff69647.png)

See https://stackoverflow.com/questions/16262854/pcntl-not-working-on-ubuntu-for-security-reasons
