### PR TITLE
Fix IPv4 addresses using octal and hexadecimal notation

### DIFF
--- a/src/main/php/peer/net/Inet4Address.class.php
+++ b/src/main/php/peer/net/Inet4Address.class.php
@@ -1,5 +1,7 @@
 <?php namespace peer\net;
 
+use lang\FormatException;
+
 /**
  * IPv4 address
  *
@@ -9,21 +11,38 @@
 class Inet4Address implements InetAddress {
 
   /**
-   * Convert IPv4 address from dotted form into a long
+   * Convert IPv4 address from dotted form into a long. Supports hexadecimal and
+   * octal notations. Yes, 0177.0.0.1 and 0x7F.0.0.1 are both equivalent with
+   * 127.0.0.1 - localhost!
    *
-   * @param   string ip
-   * @return  int
+   * @param  string $ip
+   * @return int
+   * @throws lang.FormatException
    */
   protected static function ip2long($ip) {
     $i= 0; $addr= 0; $count= 0;
     foreach (explode('.', $ip) as $byte) {
-      if (++$count > 4)
-        throw new \lang\FormatException('Given IP string has more than 4 blocks: ['.$ip.']');
+      if (++$count > 4) {
+        throw new FormatException('Given IP string has more than 4 blocks: ['.$ip.']');
+      }
 
-      if (!is_numeric($byte) || $byte < 0 || $byte > 255)
-        throw new \lang\FormatException('Invalid format of ip address: ['.$ip.']');
+      $l= strlen($byte);
+      $n= -1;
+      if ($l > 1 && '0' === $byte[0]) {
+        if ('x' === $byte[1] || 'X' === $byte[1] && $l === strspn($byte, '0123456789aAbBcCdDeEfF', 2) + 2) {
+          $n= hexdec($byte);
+        } else if ($l === strspn($byte, '0123456789')) {
+          $n= octdec($byte);
+        }
+      } else if ($l === strspn($byte, '0123456789')) {
+        $n= (int)$byte;
+      }
 
-      $addr|= ($byte << (8 * (3 - $i++)));
+      if ($n < 0 || $n > 255) {
+        throw new FormatException('Invalid format of IP address: ['.$ip.']'); 
+      }
+
+      $addr|= ($n << (8 * (3 - $i++)));
     }
     return $addr;
   }
@@ -31,8 +50,8 @@ class Inet4Address implements InetAddress {
   /**
    * Constructor
    *
-   * @param   string address
-   * @throws  lang.FormatException in case address is illegal
+   * @param  string $address
+   * @throws lang.FormatException in case address is illegal
    */
   public function __construct($address) {
     $this->addr= self::ip2long($address);
@@ -71,7 +90,7 @@ class Inet4Address implements InetAddress {
    * @return  bool
    */
   public function isLoopback() {
-    return $this->addr >> 8 == 0x7F0000;
+    return $this->addr >> 8 === 0x7F0000;
   }
   
   /**
@@ -86,18 +105,18 @@ class Inet4Address implements InetAddress {
     
     $addrn= $net->getAddress()->addr;
     $mask= $net->getNetmask();
-    return $this->addr >> (32 - $mask) == $addrn >> (32 - $mask);
+    return $this->addr >> (32 - $mask) === $addrn >> (32 - $mask);
   }
   
   /**
    * Create a subnet of this address, with the specified size.
    *
    * @param   int subnetSize
-   * @return  Network
+   * @return  peer.net.Network
    * @throws  lang.IllegalArgumentException in case the subnetSize is not correct
    */
   public function createSubnet($subnetSize) {
-    $addr= $this->addr & (0xFFFFFFFF << (32-$subnetSize));
+    $addr= $this->addr & (0xFFFFFFFF << (32 - $subnetSize));
     return new Network(new Inet4Address(long2ip($addr)), $subnetSize);
   }
 

--- a/src/main/php/peer/net/Inet4Address.class.php
+++ b/src/main/php/peer/net/Inet4Address.class.php
@@ -34,7 +34,7 @@ class Inet4Address implements InetAddress {
         } else if ($l === strspn($byte, '0123456789')) {
           $n= octdec($byte);
         }
-      } else if ($l === strspn($byte, '0123456789')) {
+      } else if ($l > 0 && $l === strspn($byte, '0123456789')) {
         $n= (int)$byte;
       }
 

--- a/src/main/php/peer/net/Inet4Address.class.php
+++ b/src/main/php/peer/net/Inet4Address.class.php
@@ -29,7 +29,7 @@ class Inet4Address implements InetAddress {
       $l= strlen($byte);
       $n= -1;
       if ($l > 1 && '0' === $byte[0]) {
-        if ('x' === $byte[1] || 'X' === $byte[1] && $l === strspn($byte, '0123456789aAbBcCdDeEfF', 2) + 2) {
+        if (('x' === $byte[1] || 'X' === $byte[1]) && $l === strspn($byte, '0123456789aAbBcCdDeEfF', 2) + 2) {
           $n= hexdec($byte);
         } else if ($l === strspn($byte, '0123456789')) {
           $n= octdec($byte);

--- a/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
+++ b/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
@@ -2,13 +2,18 @@
 
 use lang\FormatException;
 use peer\net\{Inet4Address, Network};
-use unittest\{Expect, Test};
+use unittest\{Expect, Test, Values, TestCase};
 
-class Inet4AddressTest extends \unittest\TestCase {
+class Inet4AddressTest extends TestCase {
 
-  #[Test]
-  public function createAddress() {
-    $this->assertEquals('127.0.0.1', (new Inet4Address('127.0.0.1'))->asString());
+  /** @return iterable */
+  private function localhost() {
+    return [['127.0.0.1'], ['0177.0000.000.01'], ['0177.0.0.1'], ['0x7F.0.0.1'], ['0X7F.0.0.1']];
+  }
+
+  #[Test, Values('localhost')]
+  public function createAddress($addr) {
+    $this->assertEquals('127.0.0.1', (new Inet4Address($addr))->asString());
   }
 
   #[Test, Expect(FormatException::class)]
@@ -26,9 +31,9 @@ class Inet4AddressTest extends \unittest\TestCase {
     new Inet4Address('10.0.0.255.5');
   }
 
-  #[Test]
-  public function loopbackAddress() {
-    $this->assertTrue((new Inet4Address('127.0.0.1'))->isLoopback());
+  #[Test, Values('localhost')]
+  public function loopbackAddress($addr) {
+    $this->assertTrue((new Inet4Address($addr))->isLoopback());
   }
   
   #[Test]

--- a/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
+++ b/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
@@ -8,7 +8,7 @@ class Inet4AddressTest extends TestCase {
 
   /** @return iterable */
   private function localhost() {
-    return [['127.0.0.1'], ['0177.0000.000.01'], ['0177.0.0.1'], ['0x7F.0.0.1'], ['0X7F.0.0.1']];
+    return [['127.0.0.1'], ['0177.0000.000.01'], ['0177.0.0.1'], ['0x7F.0.0.1'], ['0x7f.0.0.1'], ['0X7F.0.0.1']];
   }
 
   #[Test, Values('localhost')]

--- a/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
+++ b/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
@@ -31,6 +31,16 @@ class Inet4AddressTest extends TestCase {
     new Inet4Address('10.0.0.255.5');
   }
 
+  #[Test, Expect(FormatException::class)]
+  public function invalidHexRaisesException() {
+    new Inet4Address('0xZZ.0.0.1');
+  }
+
+  #[Test, Expect(FormatException::class)]
+  public function invalidOctalRaisesException() {
+    new Inet4Address('0ABC.0.0.1');
+  }
+
   #[Test, Values('localhost')]
   public function loopbackAddress($addr) {
     $this->assertTrue((new Inet4Address($addr))->isLoopback());

--- a/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
+++ b/src/test/php/peer/unittest/net/Inet4AddressTest.class.php
@@ -22,6 +22,11 @@ class Inet4AddressTest extends TestCase {
   }
 
   #[Test, Expect(FormatException::class)]
+  public function emptySegmentRaisesException() {
+    new Inet4Address('127.0..1');
+  }
+
+  #[Test, Expect(FormatException::class)]
   public function createInvalidAddressThatLooksLikeAddressRaisesException() {
     new Inet4Address('10.0.0.355');
   }


### PR DESCRIPTION
## What this pull request is about

Yes, 0177.0.0.1 and 0x7F.0.0.1 are both equivalent with 127.0.0.1

> [inet_aton()] also allowed the numbers to be written in hexadecimal and octal representations, by prefixing them with 0x and 0, respectively. These features continue to be supported in some software, even though they are considered as non-standard

See https://en.m.wikipedia.org/wiki/Dot-decimal_notation and https://blog.malwarebytes.com/exploits-and-vulnerabilities/2021/03/the-npm-netmask-vulnerability-explained-so-you-can-actually-understand-it/

*"Some software" actually includes Chrome, Edge, ping, even Internet Explorer.*

## Before

```bash
# The same vulnerability as NPM!
$ xp -w 'use peer\net\Inet4Address; new Inet4Address("0177.0.0.1")'
peer.net.Inet4Address(177.0.0.1)

# Unsupported
$ xp -w 'use peer\net\Inet4Address; new Inet4Address("0x7F.0.0.1")'
Uncaught exception: Exception lang.FormatException (Invalid format of ip address: [0x7F.0.0.1])
  ...
```

## After

```bash
# Octal
$ xp -w 'use peer\net\Inet4Address; new Inet4Address("0177.0.0.1")'
peer.net.Inet4Address(127.0.0.1)

# Hexadecimal
$ xp -w 'use peer\net\Inet4Address; new Inet4Address("0x7F.0.0.1")'
peer.net.Inet4Address(127.0.0.1)
```