### PR TITLE
Add Socket::open() to asynchronously connect

### DIFF
--- a/src/main/php/peer/BSDSocket.class.php
+++ b/src/main/php/peer/BSDSocket.class.php
@@ -145,14 +145,14 @@ class BSDSocket extends Socket {
     if (null === $this->_sock) return false;
 
     // For asynchronously connected sockets, check whether we can get the
-    // peer name. Once we get one, we've successfully established a connection
-    // and need not repeat this.
+    // peer name. Once we get one, we've successfully established a connection!
     if (1 === $this->state) {
       if (false === socket_getpeername($this->_sock, $_, $_)) {
         \xp::gc(__FILE__, __LINE__ - 1);
         return false;
       }
 
+      socket_set_block($this->_sock);
       $this->state= 2;
     }
 

--- a/src/main/php/peer/Sockets.class.php
+++ b/src/main/php/peer/Sockets.class.php
@@ -51,7 +51,8 @@ abstract class Sockets extends Enum {
 
       public function select0(&$r, &$w, &$e, $timeout= null) {
         if (null === $timeout) {
-          $tv_sec= $tv_usec= null;
+          $tv_sec= null;
+          $tv_usec= 0;
         } else {
           $tv_sec= (int)floor($timeout);
           $tv_usec= (int)(($timeout - $tv_sec)  * 1000000);

--- a/src/test/php/peer/unittest/sockets/AbstractSocketTest.class.php
+++ b/src/test/php/peer/unittest/sockets/AbstractSocketTest.class.php
@@ -384,4 +384,27 @@ abstract class AbstractSocketTest extends \unittest\TestCase {
 
     $this->assertEquals(['fixture' => $this->fixture], $r);
   }
+
+  #[Test]
+  public function open_connection_asynchronously() {
+    $this->fixture->open();
+
+    $read= $write= $error= [$this->fixture];
+    $this->fixture->kind()->select($read, $write, $error);
+
+    $this->assertTrue($this->fixture->isConnected());
+  }
+
+  #[Test]
+  public function open_connection_to_unbound_port() {
+
+    // Use port 4 which is unassigned and thus VERY unlikely to be bound, see
+    // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+    $fixture= $this->newSocket(self::$bindAddress[0], 4);
+    $fixture->open();
+    $read= $write= $error= [$fixture];
+    $fixture->kind()->select($read, $write, $error);
+
+    $this->assertFalse($fixture->isConnected());
+  }
 }

--- a/src/test/php/peer/unittest/sockets/SocketTest.class.php
+++ b/src/test/php/peer/unittest/sockets/SocketTest.class.php
@@ -4,11 +4,6 @@ use peer\Socket;
 use peer\unittest\StartServer;
 use unittest\actions\VerifyThat;
 
-/**
- * TestCase
- *
- * @see      xp://peer.Socket
- */
 #[Action(eval: 'new StartServer(TestingServer::class, "connected", "shutdown")')]
 class SocketTest extends AbstractSocketTest {
 
@@ -21,5 +16,28 @@ class SocketTest extends AbstractSocketTest {
    */
   protected function newSocket($addr, $port) {
     return new Socket($addr, $port);
+  }
+
+  #[Test]
+  public function open_connection_asynchronously() {
+    $this->fixture->open();
+
+    $read= $write= $error= [$this->fixture];
+    $this->fixture->kind()->select($read, $write, $error);
+
+    $this->assertTrue($this->fixture->isConnected());
+  }
+
+  #[Test]
+  public function open_connection_to_unbound_port() {
+
+    // Use port 4 which is unassigned and thus VERY unlikely to be bound, see
+    // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
+    $fixture= $this->newSocket(self::$bindAddress[0], 4);
+    $fixture->open();
+    $read= $write= $error= [$fixture];
+    $fixture->kind()->select($read, $write, $error);
+
+    $this->assertFalse($fixture->isConnected());
   }
 }

--- a/src/test/php/peer/unittest/sockets/SocketTest.class.php
+++ b/src/test/php/peer/unittest/sockets/SocketTest.class.php
@@ -17,27 +17,4 @@ class SocketTest extends AbstractSocketTest {
   protected function newSocket($addr, $port) {
     return new Socket($addr, $port);
   }
-
-  #[Test]
-  public function open_connection_asynchronously() {
-    $this->fixture->open();
-
-    $read= $write= $error= [$this->fixture];
-    $this->fixture->kind()->select($read, $write, $error);
-
-    $this->assertTrue($this->fixture->isConnected());
-  }
-
-  #[Test]
-  public function open_connection_to_unbound_port() {
-
-    // Use port 4 which is unassigned and thus VERY unlikely to be bound, see
-    // https://en.wikipedia.org/wiki/List_of_TCP_and_UDP_port_numbers
-    $fixture= $this->newSocket(self::$bindAddress[0], 4);
-    $fixture->open();
-    $read= $write= $error= [$fixture];
-    $fixture->kind()->select($read, $write, $error);
-
-    $this->assertFalse($fixture->isConnected());
-  }
 }


### PR DESCRIPTION
Use select() and test with isConnected() whether a connection has been established after calling this.

```php
use peer\Socket;

$s= new Socket($host, $port);
$s->open();

$read= $write= $error= [$s];
$s->kind()->select($read, $write, $error);

$check= $s->isConnected();
```

* [x] peer.Socket
* [x] peer.BSDSocket

See https://gist.github.com/thekid/0b20593c563fea11def89f861aa2000f