### PR TITLE
Simplify peer.net API

### DIFF
--- a/src/main/php/peer/net/Inet4Address.class.php
+++ b/src/main/php/peer/net/Inet4Address.class.php
@@ -97,11 +97,12 @@ class Inet4Address implements InetAddress {
   /**
    * Determine whether address is in the given subnet
    *
-   * @param   string net
-   * @return  bool
-   * @throws  lang.FormatException in case net has invalid format
+   * @param  string|peer.net.Network $subnet
+   * @return bool
+   * @throws lang.FormatException in case net has invalid format
    */
-  public function inSubnet(Network $net) {
+  public function inSubnet($subnet) {
+    $net= $subnet instanceof Network ? $subnet : new Network($subnet);
     if (!$net->getAddress() instanceof self) return false;
     
     $addrn= $net->getAddress()->addr;

--- a/src/main/php/peer/net/Inet6Address.class.php
+++ b/src/main/php/peer/net/Inet6Address.class.php
@@ -8,9 +8,9 @@ use util\Objects;
  *
  * @test  xp://peer.unittest.net.Inet6AddressTest
  */
-class Inet6Address implements InetAddress {
-  protected $addr;
-  
+class Inet6Address extends InetAddress {
+  private $addr;
+
   /**
    * Constructor
    *
@@ -25,14 +25,8 @@ class Inet6Address implements InetAddress {
     }
   }
 
-  /**
-   * Retrieve size of ips of this kind in bits.
-   *
-   * @return  int
-   */
-  public function sizeInBits() {
-    return 128;
-  }
+  /** @return int */
+  public function sizeInBits() { return 128; }
 
   /**
    * Normalize address

--- a/src/main/php/peer/net/Inet6Address.class.php
+++ b/src/main/php/peer/net/Inet6Address.class.php
@@ -131,26 +131,27 @@ class Inet6Address implements InetAddress {
   /**
    * Determine whether address is in the given subnet
    *
-   * @param   string net
-   * @return  bool
-   * @throws  lang.FormatException in case net has invalid format
+   * @param  string|peer.net.Network $subnet
+   * @return bool
+   * @throws lang.FormatException in case net has invalid format
    */
-  public function inSubnet(Network $net) {
+  public function inSubnet($subnet) {
+    $net= $subnet instanceof Network ? $subnet : new Network($subnet);
+    if (!$net->getAddress() instanceof self) return false;
+
     $addr= $net->getAddress();
     $mask= $net->getNetmask();
-    
     $position= 0;
     while ($mask > 8) {
-      if ($addr->addr[$position] != $this->addr[$position]) return false;
+      if ($addr->addr[$position] !== $this->addr[$position]) return false;
       $position++;
       $mask-= 8;
     }
 
-    if ($mask > 0) {
-      return ord($addr->addr[$position]) >> (8 - $mask) == ord($this->addr[$position]) >> (8 - $mask);
-    }
-    
-    return true;
+    return $mask > 0
+      ? ord($addr->addr[$position]) >> (8 - $mask) === ord($this->addr[$position]) >> (8 - $mask)
+      : true
+    ;
   }
   
   /**

--- a/src/main/php/peer/net/Inet6Address.class.php
+++ b/src/main/php/peer/net/Inet6Address.class.php
@@ -14,8 +14,9 @@ class Inet6Address extends InetAddress {
   /**
    * Constructor
    *
-   * @param   string addr
-   * @param   bool   binary
+   * @param  string $addr
+   * @param  bool $binary
+   * @throws lang.FormatException in case address is illegal
    */
   public function __construct($addr, $binary= false) {
     if ($binary) {

--- a/src/main/php/peer/net/InetAddress.class.php
+++ b/src/main/php/peer/net/InetAddress.class.php
@@ -5,21 +5,21 @@ use lang\Value;
 /**
  * Common ancestor for IPv4 and IPv6
  */
-interface InetAddress extends Value {
+abstract class InetAddress implements Value {
 
   /**
    * Retrieve "human-readable" address
    *
-   * @return  string
+   * @return string
    */
-  public function asString();
+  public abstract function asString();
   
   /**
    * Check whether this address is a loopback address
    *
-   * @return  bool
+   * @return bool
    */
-  public function isLoopback();
+  public abstract function isLoopback();
   
   /**
    * Determine whether this address is in the given network.
@@ -28,28 +28,28 @@ interface InetAddress extends Value {
    * @return bool
    * @throws lang.FormatException in case net has invalid format
    */
-  public function inSubnet($subnet);
+  public abstract function inSubnet($subnet);
 
   /**
    * Create a subnet of this address, with the specified size.
    *
-   * @param   int subnetSize
-   * @return  peer.net.Network
-   * @throws  lang.IllegalArgumentException in case the subnetSize is not correct
+   * @param  int $size
+   * @return peer.net.Network
+   * @throws lang.IllegalArgumentException in case the $size is not correct
    */
-  public function createSubnet($subnetSize);
+  public abstract function createSubnet($size);
   
   /**
    * Retrieve size of address in bits
    *
-   * @return  int
+   * @return int
    */
-  public function sizeInBits();
+  public abstract function sizeInBits();
 
   /**
    * Retrieve reversed notation for reverse DNS lookups
    *
-   * @return  string
+   * @return string
    */
-  public function reversedNotation();
+  public abstract function reversedNotation();
 }

--- a/src/main/php/peer/net/InetAddress.class.php
+++ b/src/main/php/peer/net/InetAddress.class.php
@@ -24,11 +24,11 @@ interface InetAddress extends Value {
   /**
    * Determine whether this address is in the given network.
    *
-   * @param   peer.net.Network net
-   * @return  bool
-   * @throws  lang.FormatException in case net has invalid format
+   * @param  string|peer.net.Network $subnet
+   * @return bool
+   * @throws lang.FormatException in case net has invalid format
    */
-  public function inSubnet(Network $net);
+  public function inSubnet($subnet);
 
   /**
    * Create a subnet of this address, with the specified size.

--- a/src/main/php/peer/net/InetAddress.class.php
+++ b/src/main/php/peer/net/InetAddress.class.php
@@ -1,9 +1,11 @@
 <?php namespace peer\net;
 
-use lang\Value;
+use lang\{Value, FormatException, IllegalArgumentException};
 
 /**
  * Common ancestor for IPv4 and IPv6
+ *
+ * @test  peer.unittest.net.InetAddressTest
  */
 abstract class InetAddress implements Value {
 
@@ -52,4 +54,19 @@ abstract class InetAddress implements Value {
    * @return string
    */
   public abstract function reversedNotation();
+
+  /**
+   * Returns an IPv4 or IPv6 address based on the given input
+   *
+   * @throws lang.FormatException
+   */
+  public static function new(string $arg): self {
+    if (preg_match('/^[a-fA-F0-9x\.]+$/', $arg)) {
+      return new Inet4Address($arg);
+    } else if (preg_match('/^[a-f0-9\:]+$/', $arg)) {
+      return new Inet6Address($arg);
+    } else {
+      throw new FormatException('Given argument does not look like an IP address: '.$arg);
+    }
+  }
 }

--- a/src/main/php/peer/net/InetAddressFactory.class.php
+++ b/src/main/php/peer/net/InetAddressFactory.class.php
@@ -13,7 +13,7 @@ class InetAddressFactory {
    * Parse address from string
    *
    * @param  string $input
-   * @return peer.InetAddress
+   * @return peer.net.InetAddress
    * @throws lang.FormatException if address could not be matched
    */
   public function parse(string $input) {
@@ -30,7 +30,7 @@ class InetAddressFactory {
    * Parse address from string, return NULL on failure
    *
    * @param  string $input
-   * @return ?peer.InetAddress
+   * @return ?peer.net.InetAddress
    */
   public function tryParse(string $input) {
     if (preg_match('#^[a-fA-F0-9x\.]+$#', $input)) {

--- a/src/main/php/peer/net/InetAddressFactory.class.php
+++ b/src/main/php/peer/net/InetAddressFactory.class.php
@@ -1,41 +1,41 @@
 <?php namespace peer\net;
 
+use lang\FormatException;
+
 /**
- * InetAddress Factory
+ * Parses string notations into `peer.net.InetAddress` instances.
  *
- * @test  xp://peer.unittest.net.InetAddressFactoryTest
+ * @test  peer.unittest.net.InetAddressFactoryTest
  */
 class InetAddressFactory {
 
   /**
    * Parse address from string
    *
-   * @param   string string
-   * @return  peer.InetAddress
-   * @throws  lang.FormatException if address could not be matched
+   * @param  string $input
+   * @return peer.InetAddress
+   * @throws lang.FormatException if address could not be matched
    */
-  public function parse($string) {
-    if (preg_match('#^[a-fA-F0-9x\.]+$#', $string)) {
-      return new Inet4Address($string);
+  public static function parse(string $input) {
+    if (preg_match('#^[a-fA-F0-9x\.]+$#', $input)) {
+      return new Inet4Address($input);
+    } else if (preg_match('#^[a-f0-9\:]+$#', $input)) {
+      return new Inet6Address($input);
+    } else {
+      throw new FormatException('Given argument does not look like an IP address: '.$input);
     }
-
-    if (preg_match('#^[a-f0-9\:]+$#', $string)) {
-      return new Inet6Address($string);
-    }
-
-    throw new \lang\FormatException('Given argument does not look like an IP address: '.$string);
   }
 
   /**
    * Parse address from string, return NULL on failure
    *
-   * @param   string string
-   * @return  peer.InetAddress
+   * @param  string $input
+   * @return ?peer.InetAddress
    */
-  public function tryParse($string) {
+  public static function tryParse(string $input) {
     try {
-      return $this->parse($string);
-    } catch (\lang\FormatException $e) {
+      return self::parse($input);
+    } catch (FormatException $e) {
       return null;
     }
   }

--- a/src/main/php/peer/net/InetAddressFactory.class.php
+++ b/src/main/php/peer/net/InetAddressFactory.class.php
@@ -33,9 +33,13 @@ class InetAddressFactory {
    * @return ?peer.InetAddress
    */
   public static function tryParse(string $input) {
-    try {
-      return self::parse($input);
-    } catch (FormatException $e) {
+    if (preg_match('#^[a-fA-F0-9x\.]+$#', $input)) {
+      $addr= Inet4Address::parse($input, false);
+      return null === $addr ? null : new Inet4Address($addr);
+    } else if (preg_match('#^[a-f0-9\:]+$#', $input)) {
+      $addr= Inet6Address::parse($input, false);
+      return null === $addr ? null : new Inet6Address($addr, true);
+    } else {
       return null;
     }
   }

--- a/src/main/php/peer/net/InetAddressFactory.class.php
+++ b/src/main/php/peer/net/InetAddressFactory.class.php
@@ -16,7 +16,7 @@ class InetAddressFactory {
    * @return peer.InetAddress
    * @throws lang.FormatException if address could not be matched
    */
-  public static function parse(string $input) {
+  public function parse(string $input) {
     if (preg_match('#^[a-fA-F0-9x\.]+$#', $input)) {
       return new Inet4Address($input);
     } else if (preg_match('#^[a-f0-9\:]+$#', $input)) {
@@ -32,7 +32,7 @@ class InetAddressFactory {
    * @param  string $input
    * @return ?peer.InetAddress
    */
-  public static function tryParse(string $input) {
+  public function tryParse(string $input) {
     if (preg_match('#^[a-fA-F0-9x\.]+$#', $input)) {
       $addr= Inet4Address::parse($input, false);
       return null === $addr ? null : new Inet4Address($addr);

--- a/src/main/php/peer/net/NameserverLookup.class.php
+++ b/src/main/php/peer/net/NameserverLookup.class.php
@@ -28,7 +28,7 @@ class NameserverLookup {
    * Lookup all inet4 addresses
    *
    * @param   string host
-   * @return  peer.netInet4Address[]
+   * @return  peer.net.Inet4Address[]
    */
   public function lookupAllInet4($host) {
     $res= [];
@@ -43,7 +43,7 @@ class NameserverLookup {
    * Lookup inet4 address
    *
    * @param   string host
-   * @return  peer.netInet4Address
+   * @return  peer.net.Inet4Address
    */
   public function lookupInet4($host) {
     $addr= $this->_nativeLookup($host, DNS_A);
@@ -105,7 +105,7 @@ class NameserverLookup {
    * Lookup inet4 address
    *
    * @param   string host
-   * @return  peer.netInet4Address
+   * @return  peer.net.Inet4Address
    */
   public function lookup($host) {
     $addr= $this->_nativeLookup($host, DNS_A|DNS_AAAA);
@@ -118,7 +118,7 @@ class NameserverLookup {
   /**
    * Perform reverse lookup for given address
    *
-   * @param   peer.InetAddress addr
+   * @param   peer.net.InetAddress addr
    * @return  string
    * @throws  lang.ElementNotFoundException in case no reverse lookup exists
    */
@@ -133,7 +133,7 @@ class NameserverLookup {
    * Try to perform reverse lookup for given address; if no reverse lookup
    * exists, returns NULL.
    *
-   * @param   peer.InetAddress addr
+   * @param   peer.net.InetAddress addr
    * @return  string
    */
   public function tryReverseLookup(InetAddress $addr) {

--- a/src/main/php/peer/net/Network.class.php
+++ b/src/main/php/peer/net/Network.class.php
@@ -23,7 +23,7 @@ class Network implements Value {
       $this->address= $address;
     } else {
       sscanf($address, '%[^/]/%d', $base, $netmask);
-      $this->address= InetAddressFactory::parse($base);
+      $this->address= InetAddress::new($base);
     }
 
     $size= $this->address->sizeInBits();
@@ -76,7 +76,7 @@ class Network implements Value {
    * @return bool
    */
   public function contains($address) {
-    return ($address instanceof InetAddress ? $address : InetAddressFactory::parse($address))->inSubnet($this);
+    return ($address instanceof InetAddress ? $address : InetAddress::new($address))->inSubnet($this);
   }
 
   /** @return string */

--- a/src/main/php/peer/net/Network.class.php
+++ b/src/main/php/peer/net/Network.class.php
@@ -14,7 +14,7 @@ class Network implements Value {
   /**
    * Constructor
    *
-   * @param  string|peer.InetAddress $address
+   * @param  string|peer.net.InetAddress $address
    * @param  ?int $netmask
    * @throws lang.FormatException
    */
@@ -36,7 +36,7 @@ class Network implements Value {
   /**
    * Acquire address
    *
-   * @return  peer.InetAddress
+   * @return  peer.net.InetAddress
    */
   public function getAddress() {
     return $this->address;
@@ -63,7 +63,7 @@ class Network implements Value {
   /**
    * Get base / network IP
    *
-   * @return  peer.InetAddress
+   * @return  peer.net.InetAddress
    */
   public function getNetworkAddress() {
     return $this->address;
@@ -72,7 +72,7 @@ class Network implements Value {
   /**
    * Determine whether given address is part of this network
    *
-   * @param  string|peer.InetAddress $address
+   * @param  string|peer.net.InetAddress $address
    * @return bool
    */
   public function contains($address) {

--- a/src/main/php/peer/net/NetworkParser.class.php
+++ b/src/main/php/peer/net/NetworkParser.class.php
@@ -8,6 +8,12 @@ use lang\FormatException;
  * @test  peer.unittest.net.NetworkParserTest
  */
 class NetworkParser {
+  private $addresses;
+
+  /** Constructor */
+  public function __construct() {
+    $this->addresses= new InetAddressFactory();
+  }
 
   /**
    * Parse given string into network object
@@ -21,7 +27,7 @@ class NetworkParser {
       throw new FormatException('Given string cannot be parsed to network: '.$input);
     }
 
-    return new Network(InetAddressFactory::parse($base), $netmask);
+    return new Network($this->addresses->parse($base), $netmask);
   }
 
   /**
@@ -33,7 +39,7 @@ class NetworkParser {
   public function tryParse(string $input) {
     $valid= (
       (2 === sscanf($input, '%[^/]/%d', $base, $netmask)) &&
-      ($address= InetAddressFactory::tryParse($base)) &&
+      ($address= $this->addresses->tryParse($base)) &&
       ($netmask >= 0) && 
       ($netmask <= $address->sizeInBits())
     );

--- a/src/main/php/peer/net/NetworkParser.class.php
+++ b/src/main/php/peer/net/NetworkParser.class.php
@@ -1,46 +1,43 @@
 <?php namespace peer\net;
 
+use lang\FormatException;
+
 /**
- * Description of NetworkParser
+ * Parses string notations into `peer.net.Network` instances.
  *
- * @test  xp://peer.unittest.net.NetworkParserTest
+ * @test  peer.unittest.net.NetworkParserTest
  */
 class NetworkParser {
-  protected $addressParser  = null;
-
-  /**
-   * Constructor
-   *
-   */
-  public function __construct() {
-    $this->addressParser= new InetAddressFactory();
-  }
 
   /**
    * Parse given string into network object
    *
-   * @param   string string
-   * @return  peer.Network
-   * @throws  lang.FormatException if string could not be parsed
+   * @param  string $input
+   * @return peer.Network
+   * @throws lang.FormatException if string could not be parsed
    */
-  public function parse($string) {
-    if (2 !== sscanf($string, '%[^/]/%d$', $addr, $mask)) 
-      throw new \lang\FormatException('Given string cannot be parsed to network: ['.$string.']');
+  public function parse(string $input) {
+    if (2 !== sscanf($input, '%[^/]/%d', $base, $netmask)) {
+      throw new FormatException('Given string cannot be parsed to network: '.$input);
+    }
 
-    return new Network($this->addressParser->parse($addr), $mask);
+    return new Network(InetAddressFactory::parse($base), $netmask);
   }
 
   /**
    * Parse given string into network object, return NULL if it fails.
    *
-   * @param   string string
-   * @return  peer.Network
+   * @param  string $input
+   * @return ?peer.Network
    */
-  public function tryParse($string) {
-    try {
-      return $this->parse($string);
-    } catch (\lang\FormatException $e) {
-      return null;
-    }
+  public function tryParse(string $input) {
+    $valid= (
+      (2 === sscanf($input, '%[^/]/%d', $base, $netmask)) &&
+      ($address= InetAddressFactory::tryParse($base)) &&
+      ($netmask >= 0) && 
+      ($netmask <= $address->sizeInBits())
+    );
+
+    return $valid ? new Network($address, $netmask) : null;
   }
 }

--- a/src/main/php/peer/net/NetworkParser.class.php
+++ b/src/main/php/peer/net/NetworkParser.class.php
@@ -19,7 +19,7 @@ class NetworkParser {
    * Parse given string into network object
    *
    * @param  string $input
-   * @return peer.Network
+   * @return peer.net.Network
    * @throws lang.FormatException if string could not be parsed
    */
   public function parse(string $input) {
@@ -34,7 +34,7 @@ class NetworkParser {
    * Parse given string into network object, return NULL if it fails.
    *
    * @param  string $input
-   * @return ?peer.Network
+   * @return ?peer.net.Network
    */
   public function tryParse(string $input) {
     $valid= (

--- a/src/test/php/peer/unittest/net/InetAddressFactoryTest.class.php
+++ b/src/test/php/peer/unittest/net/InetAddressFactoryTest.class.php
@@ -2,7 +2,7 @@
 
 use lang\FormatException;
 use peer\net\{Inet4Address, Inet6Address, InetAddressFactory};
-use unittest\{Expect, Test, TestCase};
+use unittest\{Expect, Test, Values, TestCase};
 
 class InetAddressFactoryTest extends TestCase {
   private $cut;
@@ -28,13 +28,18 @@ class InetAddressFactoryTest extends TestCase {
   }
 
   #[Test]
-  public function tryParse() {
+  public function tryParse_v4() {
     $this->assertEquals(new Inet4Address('172.17.29.6'), $this->cut->tryParse('172.17.29.6'));
   }
 
   #[Test]
-  public function tryParseReturnsNullOnFailure() {
-    $this->assertEquals(null, $this->cut->tryParse('not an ip address'));
+  public function tryParse_v6() {
+    $this->assertEquals(new Inet6Address('::1'), $this->cut->tryParse('::1'));
+  }
+
+  #[Test, Values(['', '3.33.333.333', '10..3.3', '::ffffff:::::a', 'not an ip address'])]
+  public function tryParseReturnsNullOnFailure($input) {
+    $this->assertEquals(null, $this->cut->tryParse($input));
   }
 
   #[Test]

--- a/src/test/php/peer/unittest/net/InetAddressTest.class.php
+++ b/src/test/php/peer/unittest/net/InetAddressTest.class.php
@@ -1,0 +1,23 @@
+<?php namespace peer\unittest\net;
+
+use lang\FormatException;
+use peer\net\{InetAddress, Inet4Address, Inet6Address};
+use unittest\{Assert, Expect, Test};
+
+class InetAddressTest {
+
+  #[Test]
+  public function new_v4() {
+    Assert::instance(Inet4Address::class, InetAddress::new('127.0.0.1'));
+  }
+
+  #[Test]
+  public function new_v6() {
+    Assert::instance(Inet6Address::class, InetAddress::new('::1'));
+  }
+
+  #[Test, Expect(FormatException::class)]
+  public function new_from_invalid() {
+    InetAddress::new('...');
+  }
+}

--- a/src/test/php/peer/unittest/net/NetworkTest.class.php
+++ b/src/test/php/peer/unittest/net/NetworkTest.class.php
@@ -2,71 +2,86 @@
 
 use lang\FormatException;
 use peer\net\{Inet4Address, Inet6Address, Network};
-use unittest\{Expect, Test};
+use unittest\{Assert, Expect, Test, Values};
 
-class NetworkTest extends \unittest\TestCase {
+class NetworkTest {
 
   #[Test]
-  public function createNetwork() {
-    $net= new Network(new Inet4Address("127.0.0.1"), 24);
-    $this->assertEquals('127.0.0.1/24', $net->asString());
+  public function create_from_v4_address() {
+    $net= new Network(new Inet4Address('127.0.0.1'), 24);
+    Assert::equals('127.0.0.1/24', $net->asString());
+  }
+
+  #[Test]
+  public function create_from_v4_string() {
+    $net= new Network('127.0.0.1', 24);
+    Assert::equals('127.0.0.1/24', $net->asString());
+  }
+
+  #[Test]
+  public function create_with_v4_string_containing_netmask() {
+    $net= new Network('127.0.0.1/24');
+    Assert::equals('127.0.0.1/24', $net->asString());
+  }
+
+  #[Test]
+  public function create_from_v6_address() {
+    $net= new Network(new Inet6Address('fe00::'), 7);
+    Assert::equals('fe00::/7', $net->asString());
+  }
+
+  #[Test]
+  public function create_from_v6_string() {
+    $net= new Network('fe00::', 7);
+    Assert::equals('fe00::/7', $net->asString());
+  }
+
+  #[Test]
+  public function create_with_v6_string_containing_netmask() {
+    $net= new Network('fe00::/24');
+    Assert::equals('fe00::/24', $net->asString());
+  }
+
+  #[Test]
+  public function create_from_v6_address_with_netmask_too_big_for_v4() {
+    $net= new Network(new Inet6Address('fe00::'), 35);
+    Assert::equals('fe00::/35', $net->asString());
+  }
+
+  #[Test, Values([['127.0.0.1', 33], ['fe00::', 763]]), Expect(FormatException::class)]
+  public function netmask_too_big($address, $netmask) {
+    new Network($address, $netmask);
+  }
+
+  #[Test, Values([['127.0.0.1', -1], ['fe00::', -1]]), Expect(FormatException::class)]
+  public function netmask_too_small($address, $netmask) {
+    new Network($address, $netmask);
   }
 
   #[Test, Expect(FormatException::class)]
-  public function createNetworkFailsIfTooLargeNetmaskGiven() {
-    new Network(new Inet4Address("127.0.0.1"), 33);
+  public function null_netmask_when_not_supplied_via_address_string() {
+    new Network('127.0.0.1', null);
   }
 
   #[Test]
-  public function createNetworkV6() {
-    $this->assertEquals(
-      'fe00::/7',
-      (new Network(new Inet6Address('fe00::'), 7))->asString()
-    );
+  public function network_address() {
+    $net= new Network('127.0.0.0/24');
+    Assert::equals(new Inet4Address('127.0.0.0'), $net->getNetworkAddress());
   }
 
   #[Test]
-  public function createNetworkV6WorkAlsoWithNetmaskTooBigInV4() {
-    $this->assertEquals(
-      'fe00::/35',
-      (new Network(new Inet6Address('fe00::'), 35))->asString()
-    );
-  }
-
-  #[Test, Expect(FormatException::class)]
-  public function createNetworkV6FailsIfTooLargeNetmaskGiven() {
-    new Network(new Inet6Address('fe00::'), 763);
-  }
-
-  #[Test, Expect(FormatException::class)]
-  public function createNetworkFailsIfTooSmallNetmaskGiven() {
-    new Network(new Inet4Address("127.0.0.1"), -1);
-  }
-
-  #[Test, Expect(FormatException::class)]
-  public function createNetworkFailsIfNonIntegerNetmaskGiven() {
-    new Network(new Inet4Address("127.0.0.1"), 0.5);
-  }
-
-  #[Test, Expect(FormatException::class)]
-  public function createNetworkFailsIfStringGiven() {
-    new Network(new Inet4Address("127.0.0.1"), "Hello");
+  public function loopback_network_contains_v4_loopback_address() {
+    Assert::true((new Network('127.0.0.5/24'))->contains(new Inet4Address('127.0.0.1')));
   }
 
   #[Test]
-  public function networkAddress() {
-    $net= new Network(new Inet4Address("127.0.0.0"), 24);
-    $this->assertEquals(new Inet4Address("127.0.0.0"), $net->getNetworkAddress());
+  public function loopback_network_contains_v4_loopback_string() {
+    Assert::true((new Network('127.0.0.5/24'))->contains('127.0.0.1'));
   }
 
   #[Test]
-  public function loopbackNetworkContainsLoopbackAddressV4() {
-    $this->assertTrue((new Network(new Inet4Address('127.0.0.5'), 24))->contains(new Inet4Address('127.0.0.1')));
-  }
-
-  #[Test]
-  public function equalNetworksAreEqual() {
-    $this->assertEquals(
+  public function equality() {
+    Assert::equals(
       new Network(new Inet4Address('127.0.0.1'), 8),
       new Network(new Inet4Address('127.0.0.1'), 8)
     );


### PR DESCRIPTION
Implements #23 and implements the "be liberal in what you accept" paradigm:

## Network constructor

```php
// Current usage
new Network(new Inet4Address('127.0.0.1'), 24);
new Network(new Inet5Address('fe00::'), 7);

// Also accepts strings now
new Network('127.0.0.1', 24);
new Network('fe00::', 7);

// Can parse netmask notation without need for NetworkParser
new Network('127.0.0.1/24');
new Network('fe00::/7');
```

## Contains

```php
// Current usage
$net->contains(new Inet4Address('127.0.0.1'));
$net->contains(new Inet6Address('::1'));

// Also accepts strings now
$net->contains('127.0.0.1');
$net->contains('::1');
```

## Subnet

```php
// Current usage
$addr->inSubnet(new Network(new Inet4Address('127.0.0.1'), 24));
$addr->inSubnet(new Network(new Inet4Address('fe00::'), 7));

// Also accepts strings now
$addr->inSubnet('127.0.0.1/24');
$addr->inSubnet('fe00::/7');
```

## Static convenience

```php
// Current usage
(new InetAddressFactory())->parse($request->header('Remote-Addr'));

// Convenience method in base class
InetAddress::new($request->header('Remote-Addr'));
```